### PR TITLE
Removed extra quotation marks

### DIFF
--- a/Entur2MQTT.php
+++ b/Entur2MQTT.php
@@ -269,12 +269,12 @@ function retrieveandpublish($url,$mqtt) {
 						$mqtt->publish($topic . "departure$i", $publishData);
 					}
 					else {
-						$mqtt->publish($topic . "departsIn$i", "'".$first."'");
-						$mqtt->publish($topic . "publicCode$i", "'".$firstpublicCode."'");
-						$mqtt->publish($topic . "Destination$i", "'".$firstDestination."'");
+						$mqtt->publish($topic . "departsIn$i", $first);
+						$mqtt->publish($topic . "publicCode$i", $firstpublicCode);
+						$mqtt->publish($topic . "Destination$i", $firstDestination);
 						if ($stopPlace) {
-							$mqtt->publish($topic . "quay$i", "'".$firstquay."'");
-							$mqtt->publish($topic . "quayname$i", "'".$firstquayname."'");
+							$mqtt->publish($topic . "quay$i", $firstquay);
+							$mqtt->publish($topic . "quayname$i", $firstquayname);
 						}
 					}
 				}


### PR DESCRIPTION
While converting from pure text output to MQTT, some extra quotation marks were left in the code. This commit removes those extra quotation marks.