### PR TITLE
Added TimeZone handling

### DIFF
--- a/Entur2MQTT.php
+++ b/Entur2MQTT.php
@@ -233,6 +233,10 @@ function retrieveandpublish($url,$mqtt) {
 
 			$found=false;
 			if($count>0) {
+				$tz=getenv("TZ");
+                if ( ! $tz ) { $tz = "Erope/Oslo"; }
+                $dtz=new DateTimeZone($tz);
+
 				$naa=new DateTime("now");
 				$mqtt->publish($topic . "time", $naa->format('H:i:s'));
 				$mqtt->publish($topic . "date", $naa->format('Y-m-d'));


### PR DESCRIPTION
Hit some obstacles regarding TimeZone when running in a standard PHP 7.4 container in Docker. Resolved by hardcoding that the script checks environment variable TZ to choose time zone. If TZ is not set, it will default to Europe/Oslo, since this script in its current form specifically only supports Norwegian public transport.